### PR TITLE
Fix error in installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Register the repository:
 
 ```
 #command line
-$ composer repositories.magento-module-yoastseo '{"type": "vcs", "url": "git@github.com:Yoast/magento-seo.git"}'
+$ composer config repositories.magento-module-yoastseo '{"type": "vcs", "url": "git@github.com:Yoast/magento-seo.git"}'
 
 # OR
 


### PR DESCRIPTION
The readme.md contains an error. The command `composer repositories...` should be `composer config repositories...`.