### PR TITLE
Fix for #42 'Class fileUploader does not exist'

### DIFF
--- a/Setup/AbstractInstallData.php
+++ b/Setup/AbstractInstallData.php
@@ -99,7 +99,7 @@ class AbstractInstallData
             'sort_order' => 20
         ]);
         $this->addProductAttribute('yoast_facebook_image', [
-            'input' => 'fileUploader',
+            'input' => 'image',
             'backend' => 'MaxServ\YoastSeo\Model\Attribute\Backend\Image',
             'label' => 'Facebook image',
             'group' => 'Yoast Facebook',
@@ -118,7 +118,7 @@ class AbstractInstallData
             'sort_order' => 20
         ]);
         $this->addProductAttribute('yoast_twitter_image', [
-            'input' => 'fileUploader',
+            'input' => 'image',
             'backend' => 'MaxServ\YoastSeo\Model\Attribute\Backend\Image',
             'label' => 'Twitter image',
             'group' => 'Yoast Twitter',
@@ -154,7 +154,7 @@ class AbstractInstallData
             'sort_order' => 20
         ]);
         $this->addCategoryAttribute('yoast_facebook_image', [
-            'input' => 'fileUploader',
+            'input' => 'image',
             'backend' => 'MaxServ\YoastSeo\Model\Attribute\Backend\Image',
             'label' => 'Facebook image',
             'group' => 'Yoast Facebook',
@@ -173,7 +173,7 @@ class AbstractInstallData
             'sort_order' => 20
         ]);
         $this->addCategoryAttribute('yoast_twitter_image', [
-            'input' => 'fileUploader',
+            'input' => 'image',
             'backend' => 'MaxServ\YoastSeo\Model\Attribute\Backend\Image',
             'label' => 'Twitter image',
             'group' => 'Yoast Twitter',


### PR DESCRIPTION
The class fileUploader, used in the `frontend_input` field doesn't seem to exist. It triggers the following error when mass updating products:

```1 exception(s):
Exception #0 (ReflectionException): Class fileUploader does not exist

Exception #0 (ReflectionException): Class fileUploader does not exist
#0 /data/ssd/vhosts/local.dev/magento2/vendor/magento/framework/Code/Reader/ClassReader.php(19): ReflectionClass->__construct('fileUploader')
#1 /data/ssd/vhosts/local.dev/magento2/vendor/magento/framework/ObjectManager/Definition/Runtime.php(44): Magento\Framework\Code\Reader\ClassReader->getConstructor('fileUploader')
#2 /data/ssd/vhosts/local.dev/magento2/vendor/magento/framework/ObjectManager/Factory/Dynamic/Developer.php(71): Magento\Framework\ObjectManager\Definition\Runtime->getParameters('fileUploader')
#3 /data/ssd/vhosts/local.dev/magento2/vendor/magento/framework/ObjectManager/ObjectManager.php(57): Magento\Framework\ObjectManager\Factory\Dynamic\Developer->create('fileUploader', Array)
#4 /data/ssd/vhosts/local.dev/magento2/vendor/magento/framework/Data/Form/Element/Factory.php(81): Magento\Framework\ObjectManager\ObjectManager->create('fileUploader', Array)
#5 /data/ssd/vhosts/local.dev/magento2/vendor/magento/framework/Data/Form/AbstractForm.php(155): Magento\Framework\Data\Form\Element\Factory->create('fileUploader', Array)
```

I've changed the `frontend_input` to `image`, this seems to solve the issue in my case.