### PR TITLE
Fix a casing issue with the PHPDoc in the search results interface. 

### DIFF
--- a/Api/Data/AnalysisTemplateSearchResultsInterface.php
+++ b/Api/Data/AnalysisTemplateSearchResultsInterface.php
@@ -7,12 +7,12 @@ use Magento\Framework\Api\SearchResultsInterface;
 interface AnalysisTemplateSearchResultsInterface extends SearchResultsInterface
 {
     /**
-     * @return \MaxServ\YoastSEO\Api\Data\AnalysisTemplateInterface[]
+     * @return \MaxServ\YoastSeo\Api\Data\AnalysisTemplateInterface[]
      */
     public function getItems();
 
     /**
-     * @param \MaxServ\YoastSEO\Api\Data\AnalysisTemplateInterface[] $items
+     * @param \MaxServ\YoastSeo\Api\Data\AnalysisTemplateInterface[] $items
      * @return $this
      */
     public function setItems(array $items);


### PR DESCRIPTION
What you were trying to achieve.
- With the Yoast SEO extension installed on Magento 2.2.5. I am trying to use swagger (https://example.test/swagger?store=default).

What you were expecting to happen.
- I am expected swagger to load and work.

What actually happened, illustrated with screenshots if possible.
- The swagger documentation is no longer working. I am getting the error: `Failed to load API definition.`
- The URL https://example.test/rest/default/schema?services=all is showing this error message: `Class "\MaxServ\YoastSEO\Api\Data\AnalysisTemplateInterface[]" does not exist. Please note that namespace must be specified.`

This pull request is to fix the namespace in the phpdocs in the class AnalysisTemplateSearchResultsInterface. I changed YoastSEO to YoastSeo.
