### PR TITLE
fix capitalized namespace in api definition

### DIFF
--- a/Api/Data/AnalysisTemplateSearchResultsInterface.php
+++ b/Api/Data/AnalysisTemplateSearchResultsInterface.php
@@ -7,12 +7,12 @@ use Magento\Framework\Api\SearchResultsInterface;
 interface AnalysisTemplateSearchResultsInterface extends SearchResultsInterface
 {
     /**
-     * @return \MaxServ\YoastSEO\Api\Data\AnalysisTemplateInterface[]
+     * @return \MaxServ\YoastSeo\Api\Data\AnalysisTemplateInterface[]
      */
     public function getItems();
 
     /**
-     * @param \MaxServ\YoastSEO\Api\Data\AnalysisTemplateInterface[] $items
+     * @param \MaxServ\YoastSeo\Api\Data\AnalysisTemplateInterface[] $items
      * @return $this
      */
     public function setItems(array $items);


### PR DESCRIPTION
this problem occurs when creating the api definition calling http://.../rest/all/schema?services=all

resulting in Class "\MaxServ\YoastSEO\Api\Data\AnalysisTemplateInterface[]" does not exist. Please note that namespace must be specified.