### PR TITLE
Prevent the product object from leaking to other places

### DIFF
--- a/Model/Entity/Configuration/Catalog/ProductMetaProvider.php
+++ b/Model/Entity/Configuration/Catalog/ProductMetaProvider.php
@@ -104,11 +104,7 @@ class ProductMetaProvider extends AbstractMetaProvider
     public function getImage()
     {
         if (empty($this->image)) {
-            $image = $this->imageBuilder
-                ->setProduct($this->getProduct())
-                ->setImageId('product_base_image')
-                ->setAttributes([])
-                ->create();
+            $image = $this->imageBuilder->create($this->getProduct(), 'product_base_image', []);
 
             $this->image = $image->getImageUrl();
         }


### PR DESCRIPTION
Hi,

We bumped into a problem where the information set on the `$this->imageBuilder` instance leaked into different parts of the application, leading too hard to debug errors. In our case this caused that labels from the Amasty Label extension from the main product where shown on the related products. Changing the way the method was called solved this problem for us. We used Magento 2.3.1 when this error occurred.